### PR TITLE
Add open redirect payload

### DIFF
--- a/ava/actives/open_redirect.py
+++ b/ava/actives/open_redirect.py
@@ -66,8 +66,12 @@ class OpenRedirectCheck(_ValueCheck):
         # contains
         contains = parsed.scheme + "://" + domain + "/" + parsed.netloc
 
+        # spliced
+        spliced = domain.split('.')[:2] + parsed.netloc.split('.')[-2:]
+        spliced = parsed.scheme + "://" + "{}.{}-{}.{}".format(*spliced)
+
         # dynamic
-        dynamic = [basic_auth, starts_with, ends_with, contains]
+        dynamic = [basic_auth, starts_with, ends_with, contains, spliced]
 
         return self._payloads + dynamic
 

--- a/tests/actives/test_actives_open_redirect.py
+++ b/tests/actives/test_actives_open_redirect.py
@@ -21,7 +21,8 @@ class TestOpenRedirectCheck:
         "http://www.example.com:pass@www.avascan.com",
         "http://www.example.com.www.avascan.com",
         "http://www.avascan.com\\www.example.com",
-        "http://www.avascan.com/www.example.com"
+        "http://www.avascan.com/www.example.com",
+        "http://www.avascan-example.com"
     ]
 
     @pytest.fixture


### PR DESCRIPTION
Add dynamic open redirect payload that splices together random and current domain. This results in a payload in the form of https://www.attacker-example.com.