### PR TITLE
Add ability to specify sub-classes within the --actives parameter

### DIFF
--- a/ava/actives/code_injection.py
+++ b/ava/actives/code_injection.py
@@ -17,7 +17,7 @@ class PythonCodeInjectionTimingCheck(_TimingCheck):
     """
     key = "code.timing.python"
     name = "Python Code Injection Timing"
-    description = "Checks for Python Code Injection by executing delays"
+    description = "checks for python code injection by executing delays"
 
     def __init__(self):
         """Define static payloads"""

--- a/ava/actives/header_injection.py
+++ b/ava/actives/header_injection.py
@@ -15,7 +15,7 @@ class HeaderInjectionCheck(_ValueCheck):
     """
     key = "header.value.cookie"
     name = "Header Injection"
-    description = "Checks for Header Injection in response headers"
+    description = "checks for header injection in response headers"
 
     def __init__(self):
         """Define static payloads"""

--- a/ava/actives/open_redirect.py
+++ b/ava/actives/open_redirect.py
@@ -22,7 +22,7 @@ class OpenRedirectCheck(_ValueCheck):
     """
     key = "redirect.value.location"
     name = "Open Redirect"
-    description = "Checks for Open Redirects in the 'Location' header"
+    description = "checks for open redirects in the 'Location' header"
 
     def __init__(self):
         """Define static payloads"""
@@ -107,7 +107,7 @@ class OpenRedirectHtmlCheck(OpenRedirectCheck):
     """
     key = "redirect.value.href"
     name = "Open Redirect HTML Links"
-    description = "Checks for Open Redirects in 'href' attributes of '<a>' tags"
+    description = "checks for open redirects in 'href' attributes of '<a>' tags"
 
     def check(self, response, payload):
         """
@@ -141,7 +141,7 @@ class OpenRedirectScriptCheck(OpenRedirectCheck):
     """
     key = "redirect.value.script"
     name = "Open Redirect HTML Scripts"
-    description = "Checks for Open Redirects in 'window.location' statements of script tags"
+    description = "checks for open redirects in 'window.location' statements of script tags"
 
     def check(self, response, payload):
         """

--- a/ava/actives/path_traversal.py
+++ b/ava/actives/path_traversal.py
@@ -13,7 +13,7 @@ class PathTraversalCheck(_ValueCheck):
     """
     key = "path.value.file"
     name = "Path Traversal"
-    description = "Checks for Path Traversal by accessing local files"
+    description = "checks for path traversal by accessing local files"
 
     def __init__(self):
         """Define static payloads"""

--- a/ava/actives/shell_injection.py
+++ b/ava/actives/shell_injection.py
@@ -14,7 +14,7 @@ class ShellInjectionCheck(_ValueCheck):
     """
     key = "shell.value.command"
     name = "Shell Injection"
-    description = "Checks for Shell Injection by executing commands"
+    description = "checks for shell injection by executing commands"
 
     def __init__(self):
         """Define static payloads"""
@@ -66,7 +66,7 @@ class ShellInjectionTimingCheck(_TimingCheck):
     """
     key = "shell.timing.sleep"
     name = "Shell Injection Timing"
-    description = "Checks for Shell Injection by executing delays"
+    description = "checks for shell injection by executing delays"
 
     def __init__(self):
         """Define static payloads"""

--- a/ava/actives/sql_injection.py
+++ b/ava/actives/sql_injection.py
@@ -14,7 +14,7 @@ class SqlInjectionCheck(_ValueCheck):
     """
     key = "sql.value.error"
     name = "SQL Injection"
-    description = "Checks for SQL Injection by causing syntax errors"
+    description = "checks for sql injection by causing syntax errors"
 
     def __init__(self):
         """Define static payloads"""
@@ -59,7 +59,7 @@ class SqlInjectionDifferentialCheck(_DifferentialCheck):
     """
     key = "sql.differential.row"
     name = "SQL Injection Differential"
-    description = "Checks for SQL Injection in response body"
+    description = "checks for sql injection in response body"
 
     def __init__(self):
         """Define static payloads"""
@@ -99,7 +99,7 @@ class SqlInjectionTimingCheck(_TimingCheck):
     """
     key = "sql.timing.sleep"
     name = "SQL Injection Timing"
-    description = "Checks for SQL Injection by executing delays"
+    description = "checks for sql injection by executing delays"
 
     def __init__(self):
         """Define static payloads"""

--- a/ava/actives/xss.py
+++ b/ava/actives/xss.py
@@ -17,7 +17,7 @@ class CrossSiteScriptingCheck(_ValueCheck):
     """
     key = "xss.value.tag"
     name = "Cross-Site Scripting"
-    description = "Checks for Cross-Site Scripting by injecting HTML tags"
+    description = "checks for cross-Site scripting by injecting HTML tags"
 
     def __init__(self):
         """Define static payloads"""
@@ -75,7 +75,7 @@ class CrossSiteScriptingLinkCheck(_ValueCheck):
     """
     key = "xss.value.href"
     name = "Cross-Site Scripting HTML Links"
-    description = "Checks for Cross-Site Scripting in 'href' attributes of '<a>' tags"
+    description = "checks for cross-site scripting in 'href' attributes of '<a>' tags"
 
     def __init__(self):
         """Define static payload"""
@@ -118,7 +118,7 @@ class CrossSiteScriptingScriptSrcCheck(_ValueCheck):
     """
     key = "xss.value.src"
     name = "Cross-Site Scripting HTML Scripts Source"
-    description = "Checks for Cross-Site Scripting in 'src' attributes of '<script>' tags"
+    description = "checks for cross-site scripting in 'src' attributes of '<script>' tags"
 
     def __init__(self):
         """Define static payload"""
@@ -179,7 +179,7 @@ class CrossSiteScriptingScriptCheck(_ValueCheck):
     """
     key = "xss.value.script"
     name = "Cross-Site Scripting HTML Scripts"
-    description = "Checks for Cross-Site Scripting in HTML <script> tags"
+    description = "checks for cross-site scripting in HTML <script> tags"
 
     def __init__(self):
         """Define static payloads"""
@@ -238,7 +238,7 @@ class CrossSiteScriptingEventCheck(CrossSiteScriptingScriptCheck):
     """
     key = "xss.value.event"
     name = "Cross-Site Scripting HTML Events"
-    description = "Checks for Cross-Site Scripting in HTML event attributes"
+    description = "checks for cross-site scripting in HTML event attributes"
 
     def check(self, response, payload):
         """

--- a/ava/actives/xxe.py
+++ b/ava/actives/xxe.py
@@ -16,7 +16,7 @@ class XmlExternalEntityCheck(_ValueCheck):
     """
     key = "xxe.value.file"
     name = "XML External Entity"
-    description = "Checks for XML External Entity by accessing local files"
+    description = "checks for xml external entity by accessing local files"
 
     def __init__(self):
         """Define static payloads"""

--- a/ava/scanner.py
+++ b/ava/scanner.py
@@ -50,10 +50,14 @@ def _print_modules():
     # print names and descriptions
     for package in packages:
         print(package + ':')
-        for name, description in utility.get_package_info(package):
-            print("  {:21s} {}".format(name, description))
+        for name, description, classes in utility.get_package_info(package):
+            print("  {:26s} {}".format(name, description))
+            if package == 'actives':
+                for key, desc in classes:
+                    print("    {:24s} {}".format(key, desc))
+                print('')
 
-        if package != packages[-1]:
+        if package not in ['actives', 'passives']:
             print('')
 
 

--- a/tests/common/test_common_config.py
+++ b/tests/common/test_common_config.py
@@ -15,6 +15,10 @@ def test_check_modules_positive(mocker):
     test = config._check_modules("actives", ["xss", "open_redirect"])
     assert test == ["xss", "open_redirect"]
 
+    # key
+    test = config._check_modules("actives", ["xss.value.href"])
+    assert test == ["xss.value.href"]
+
 
 def test_check_modules_negative(mocker):
     # __init__
@@ -26,6 +30,10 @@ def test_check_modules_negative(mocker):
     mocker.patch("os.listdir", return_value=["__init__.py", "xss.py", "open_redirect.py"])
     with pytest.raises(InvalidValueException):
         config._check_modules("actives", ["module_does_not_exist"])
+
+    # non-existent key
+    with pytest.raises(InvalidValueException):
+        config._check_modules("actives", ["non.existent.key"])
 
 
 def test_check_url_positive():


### PR DESCRIPTION
Add ability to specify classes in active modules. Classes can be specified by using keys defined in each class. You can set the option like `-e xss.value.script,path.value.file` (keys can be shown by `ava --list`). This feature enables us to implement a feature setting and adding payloads to a specific class. I ignored blind parameter about this feature because it has only one class.