### PR TITLE
Add --set-payloads and --add-payloads options

### DIFF
--- a/ava/actives/code_injection.py
+++ b/ava/actives/code_injection.py
@@ -17,7 +17,7 @@ class PythonCodeInjectionTimingCheck(_TimingCheck):
     """
     key = "code.timing.python"
     name = "Python Code Injection Timing"
-    description = "Checks for Python Code Injection by executing delays"
+    description = "checks for python code injection by executing delays"
 
     def __init__(self):
         """Define static payloads"""

--- a/ava/actives/code_injection.py
+++ b/ava/actives/code_injection.py
@@ -18,6 +18,7 @@ class PythonCodeInjectionTimingCheck(_TimingCheck):
     key = "code.timing.python"
     name = "Python Code Injection Timing"
     description = "checks for python code injection by executing delays"
+    example = "__import__('time').sleep(9)"
 
     def __init__(self):
         """Define static payloads"""

--- a/ava/actives/header_injection.py
+++ b/ava/actives/header_injection.py
@@ -1,6 +1,7 @@
 import string
 from ava.common import utility
 from ava.common.check import _ValueCheck
+from ava.common.exception import InvalidFormatException
 
 
 # metadata
@@ -16,6 +17,7 @@ class HeaderInjectionCheck(_ValueCheck):
     key = "header.value.cookie"
     name = "Header Injection"
     description = "checks for header injection in response headers"
+    example = "\\r\\nSet-Cookie: {}={}"
 
     def __init__(self):
         """Define static payloads"""
@@ -46,3 +48,17 @@ class HeaderInjectionCheck(_ValueCheck):
             return True
         else:
             return False
+
+    def _check_payloads(self, payloads):
+        """
+        Checks if the payloads are adoptable for this class and modify the payloads to ajust to check function.
+        InvalidFormatException is raised, if a payload is not adoptable.
+        Children can override.
+        :param payloads: list of payloads
+        :return: list of modified payloads
+        """
+        for i, payload in enumerate(payloads):
+            if '{}={}' not in payload:
+                raise InvalidFormatException("Payload of {} must include '{{}}={{}}'".format(self.key))
+            payloads[i] = payload.format(self._random, self._random)
+        return payloads

--- a/ava/actives/header_injection.py
+++ b/ava/actives/header_injection.py
@@ -15,7 +15,7 @@ class HeaderInjectionCheck(_ValueCheck):
     """
     key = "header.value.cookie"
     name = "Header Injection"
-    description = "Checks for Header Injection in response headers"
+    description = "checks for header injection in response headers"
 
     def __init__(self):
         """Define static payloads"""

--- a/ava/actives/open_redirect.py
+++ b/ava/actives/open_redirect.py
@@ -6,6 +6,7 @@ from urllib.parse import urlparse
 from ava.common import utility
 from ava.common.check import _ValueCheck
 from ava.common.constant import HTTP
+from ava.common.exception import InvalidFormatException
 
 # ignore URL warnings from BeautifulSoup
 warnings.filterwarnings("ignore", category=UserWarning, module="bs4")
@@ -23,6 +24,7 @@ class OpenRedirectCheck(_ValueCheck):
     key = "redirect.value.location"
     name = "Open Redirect"
     description = "checks for open redirects in the 'Location' header"
+    example = "http://www.{}.com"
 
     def __init__(self):
         """Define static payloads"""
@@ -98,6 +100,20 @@ class OpenRedirectCheck(_ValueCheck):
             return True
         else:
             return False
+
+    def _check_payloads(self, payloads):
+        """
+        Checks if the payloads are adoptable for this class and modify the payloads to adjust to check function.
+        InvalidFormatException is raised, if a payload is not adoptable.
+        Children can override.
+        :param payloads: list of payloads
+        :return: list of modified payloads
+        """
+        for i, payload in enumerate(payloads):
+            if 'www.{}.com' not in payload:
+                raise InvalidFormatException("Payload of {} must include 'www.{{}}.com'".format(self.key))
+            payloads[i] = payload.format(self._random)
+        return payloads
 
 
 class OpenRedirectHtmlCheck(OpenRedirectCheck):

--- a/ava/actives/open_redirect.py
+++ b/ava/actives/open_redirect.py
@@ -22,7 +22,7 @@ class OpenRedirectCheck(_ValueCheck):
     """
     key = "redirect.value.location"
     name = "Open Redirect"
-    description = "Checks for Open Redirects in the 'Location' header"
+    description = "checks for open redirects in the 'Location' header"
 
     def __init__(self):
         """Define static payloads"""
@@ -107,7 +107,7 @@ class OpenRedirectHtmlCheck(OpenRedirectCheck):
     """
     key = "redirect.value.href"
     name = "Open Redirect HTML Links"
-    description = "Checks for Open Redirects in 'href' attributes of '<a>' tags"
+    description = "checks for open redirects in 'href' attributes of '<a>' tags"
 
     def check(self, response, payload):
         """
@@ -141,7 +141,7 @@ class OpenRedirectScriptCheck(OpenRedirectCheck):
     """
     key = "redirect.value.script"
     name = "Open Redirect HTML Scripts"
-    description = "Checks for Open Redirects in 'window.location' statements of script tags"
+    description = "checks for open redirects in 'window.location' statements of script tags"
 
     def check(self, response, payload):
         """

--- a/ava/actives/path_traversal.py
+++ b/ava/actives/path_traversal.py
@@ -13,7 +13,7 @@ class PathTraversalCheck(_ValueCheck):
     """
     key = "path.value.file"
     name = "Path Traversal"
-    description = "Checks for Path Traversal by accessing local files"
+    description = "checks for path traversal by accessing local files"
 
     def __init__(self):
         """Define static payloads"""

--- a/ava/actives/path_traversal.py
+++ b/ava/actives/path_traversal.py
@@ -1,6 +1,7 @@
 import re
 
 from ava.common.check import _ValueCheck
+from ava.common.exception import InvalidFormatException
 
 # metadata
 name = __name__
@@ -14,6 +15,7 @@ class PathTraversalCheck(_ValueCheck):
     key = "path.value.file"
     name = "Path Traversal"
     description = "checks for path traversal by accessing local files"
+    example = "../etc/group"
 
     def __init__(self):
         """Define static payloads"""
@@ -49,3 +51,16 @@ class PathTraversalCheck(_ValueCheck):
             return True
         else:
             return False
+
+    def _check_payloads(self, payloads):
+        """
+        Checks if the payloads are adoptable for this class and modify the payloads to adjust to check function.
+        InvalidFormatException is raised, if a payload is not adoptable.
+        Children can override.
+        :param payloads: list of payloads
+        :return: list of modified payloads
+        """
+        for i, payload in enumerate(payloads):
+            if 'etc/group' not in payload:
+                raise InvalidFormatException("Payload of {} must include 'etc/group' as a part of path".format(self.key))
+        return payloads

--- a/ava/actives/shell_injection.py
+++ b/ava/actives/shell_injection.py
@@ -1,5 +1,6 @@
 import re
 from ava.common.check import _ValueCheck, _TimingCheck
+from ava.common.exception import InvalidFormatException
 
 
 # metadata
@@ -15,6 +16,7 @@ class ShellInjectionCheck(_ValueCheck):
     key = "shell.value.command"
     name = "Shell Injection"
     description = "checks for shell injection by executing commands"
+    example = "; id #"
 
     def __init__(self):
         """Define static payloads"""
@@ -58,6 +60,19 @@ class ShellInjectionCheck(_ValueCheck):
         else:
             return False
 
+    def _check_payloads(self, payloads):
+        """
+        Checks if the payloads are adoptable for this class and modify the payloads to adjust to check function.
+        InvalidFormatException is raised, if a payload is not adoptable.
+        Children can override.
+        :param payloads: list of payloads
+        :return: list of modified payloads
+        """
+        for i, payload in enumerate(payloads):
+            if 'id' not in payload:
+                raise InvalidFormatException("Payload of {} must include 'id'".format(self.key))
+        return payloads
+
 
 class ShellInjectionTimingCheck(_TimingCheck):
     """
@@ -67,6 +82,7 @@ class ShellInjectionTimingCheck(_TimingCheck):
     key = "shell.timing.sleep"
     name = "Shell Injection Timing"
     description = "checks for shell injection by executing delays"
+    example = "; sleep 9 #"
 
     def __init__(self):
         """Define static payloads"""

--- a/ava/actives/shell_injection.py
+++ b/ava/actives/shell_injection.py
@@ -14,7 +14,7 @@ class ShellInjectionCheck(_ValueCheck):
     """
     key = "shell.value.command"
     name = "Shell Injection"
-    description = "Checks for Shell Injection by executing commands"
+    description = "checks for shell injection by executing commands"
 
     def __init__(self):
         """Define static payloads"""
@@ -66,7 +66,7 @@ class ShellInjectionTimingCheck(_TimingCheck):
     """
     key = "shell.timing.sleep"
     name = "Shell Injection Timing"
-    description = "Checks for Shell Injection by executing delays"
+    description = "checks for shell injection by executing delays"
 
     def __init__(self):
         """Define static payloads"""

--- a/ava/actives/sql_injection.py
+++ b/ava/actives/sql_injection.py
@@ -15,6 +15,7 @@ class SqlInjectionCheck(_ValueCheck):
     key = "sql.value.error"
     name = "SQL Injection"
     description = "checks for sql injection by causing syntax errors"
+    example = "'"
 
     def __init__(self):
         """Define static payloads"""
@@ -100,6 +101,7 @@ class SqlInjectionTimingCheck(_TimingCheck):
     key = "sql.timing.sleep"
     name = "SQL Injection Timing"
     description = "checks for sql injection by executing delays"
+    example = "' UNION SELECT SLEEP(9) -- "
 
     def __init__(self):
         """Define static payloads"""

--- a/ava/actives/sql_injection.py
+++ b/ava/actives/sql_injection.py
@@ -14,7 +14,7 @@ class SqlInjectionCheck(_ValueCheck):
     """
     key = "sql.value.error"
     name = "SQL Injection"
-    description = "Checks for SQL Injection by causing syntax errors"
+    description = "checks for sql injection by causing syntax errors"
 
     def __init__(self):
         """Define static payloads"""
@@ -59,7 +59,7 @@ class SqlInjectionDifferentialCheck(_DifferentialCheck):
     """
     key = "sql.differential.row"
     name = "SQL Injection Differential"
-    description = "Checks for SQL Injection in response body"
+    description = "checks for sql injection in response body"
 
     def __init__(self):
         """Define static payloads"""
@@ -99,7 +99,7 @@ class SqlInjectionTimingCheck(_TimingCheck):
     """
     key = "sql.timing.sleep"
     name = "SQL Injection Timing"
-    description = "Checks for SQL Injection by executing delays"
+    description = "checks for sql injection by executing delays"
 
     def __init__(self):
         """Define static payloads"""

--- a/ava/actives/xss.py
+++ b/ava/actives/xss.py
@@ -17,7 +17,7 @@ class CrossSiteScriptingCheck(_ValueCheck):
     """
     key = "xss.value.tag"
     name = "Cross-Site Scripting"
-    description = "Checks for Cross-Site Scripting by injecting HTML tags"
+    description = "checks for cross-Site scripting by injecting HTML tags"
 
     def __init__(self):
         """Define static payloads"""
@@ -75,7 +75,7 @@ class CrossSiteScriptingLinkCheck(_ValueCheck):
     """
     key = "xss.value.href"
     name = "Cross-Site Scripting HTML Links"
-    description = "Checks for Cross-Site Scripting in 'href' attributes of '<a>' tags"
+    description = "checks for cross-site scripting in 'href' attributes of '<a>' tags"
 
     def __init__(self):
         """Define static payload"""
@@ -118,7 +118,7 @@ class CrossSiteScriptingScriptSrcCheck(_ValueCheck):
     """
     key = "xss.value.src"
     name = "Cross-Site Scripting HTML Scripts Source"
-    description = "Checks for Cross-Site Scripting in 'src' attributes of '<script>' tags"
+    description = "checks for cross-site scripting in 'src' attributes of '<script>' tags"
 
     def __init__(self):
         """Define static payload"""
@@ -179,7 +179,7 @@ class CrossSiteScriptingScriptCheck(_ValueCheck):
     """
     key = "xss.value.script"
     name = "Cross-Site Scripting HTML Scripts"
-    description = "Checks for Cross-Site Scripting in HTML <script> tags"
+    description = "checks for cross-site scripting in HTML <script> tags"
 
     def __init__(self):
         """Define static payloads"""
@@ -238,7 +238,7 @@ class CrossSiteScriptingEventCheck(CrossSiteScriptingScriptCheck):
     """
     key = "xss.value.event"
     name = "Cross-Site Scripting HTML Events"
-    description = "Checks for Cross-Site Scripting in HTML event attributes"
+    description = "checks for cross-site scripting in HTML event attributes"
 
     def check(self, response, payload):
         """

--- a/ava/actives/xss.py
+++ b/ava/actives/xss.py
@@ -4,6 +4,7 @@ from bs4 import BeautifulSoup
 from ava.common import utility
 from ava.common.check import _ValueCheck
 from ava.common.constant import HTTP
+from ava.common.exception import InvalidFormatException
 
 # metadata
 name = __name__
@@ -18,6 +19,7 @@ class CrossSiteScriptingCheck(_ValueCheck):
     key = "xss.value.tag"
     name = "Cross-Site Scripting"
     description = "checks for cross-Site scripting by injecting HTML tags"
+    example = "<{}></{}>"
 
     def __init__(self):
         """Define static payloads"""
@@ -67,6 +69,20 @@ class CrossSiteScriptingCheck(_ValueCheck):
         else:
             return False
 
+    def _check_payloads(self, payloads):
+        """
+        Checks if the payloads are adoptable for this class and modify the payloads to adjust to check function.
+        InvalidFormatException is raised, if a payload is not adoptable.
+        Children can override.
+        :param payloads: list of payloads
+        :return: list of modified payloads
+        """
+        for i, payload in enumerate(payloads):
+            if '<{}' not in payload:
+                raise InvalidFormatException("Payload of {} must have a tag named '{{}}'".format(self.key))
+            payloads[i] = payload.format(self._random, self._random)
+        return payloads
+
 
 class CrossSiteScriptingLinkCheck(_ValueCheck):
     """
@@ -76,6 +92,7 @@ class CrossSiteScriptingLinkCheck(_ValueCheck):
     key = "xss.value.href"
     name = "Cross-Site Scripting HTML Links"
     description = "checks for cross-site scripting in 'href' attributes of '<a>' tags"
+    example = "javascript:{}()"
 
     def __init__(self):
         """Define static payload"""
@@ -110,6 +127,20 @@ class CrossSiteScriptingLinkCheck(_ValueCheck):
         else:
             return False
 
+    def _check_payloads(self, payloads):
+        """
+        Checks if the payloads are adoptable for this class and modify the payloads to adjust to check function.
+        InvalidFormatException is raised, if a payload is not adoptable.
+        Children can override.
+        :param payloads: list of payloads
+        :return: list of modified payloads
+        """
+        for i, payload in enumerate(payloads):
+            if '{}()' not in payload:
+                raise InvalidFormatException("Payload of {} must have a function named '{{}}'".format(self.key))
+            payloads[i] = payload.format(self._random)
+        return payloads
+
 
 class CrossSiteScriptingScriptSrcCheck(_ValueCheck):
     """
@@ -119,6 +150,7 @@ class CrossSiteScriptingScriptSrcCheck(_ValueCheck):
     key = "xss.value.src"
     name = "Cross-Site Scripting HTML Scripts Source"
     description = "checks for cross-site scripting in 'src' attributes of '<script>' tags"
+    example = "//www.{}.com/{}.js"
 
     def __init__(self):
         """Define static payload"""
@@ -171,6 +203,20 @@ class CrossSiteScriptingScriptSrcCheck(_ValueCheck):
         else:
             return False
 
+    def _check_payloads(self, payloads):
+        """
+        Checks if the payloads are adoptable for this class and modify the payloads to adjust to check function.
+        InvalidFormatException is raised, if a payload is not adoptable.
+        Children can override.
+        :param payloads: list of payloads
+        :return: list of modified payloads
+        """
+        for i, payload in enumerate(payloads):
+            if 'www.{}.com' not in payload:
+                raise InvalidFormatException("Payload of {} must have address of 'www.{{}}.com'".format(self.key))
+            payloads[i] = payload.format(self._random)
+        return payloads
+
 
 class CrossSiteScriptingScriptCheck(_ValueCheck):
     """
@@ -180,6 +226,7 @@ class CrossSiteScriptingScriptCheck(_ValueCheck):
     key = "xss.value.script"
     name = "Cross-Site Scripting HTML Scripts"
     description = "checks for cross-site scripting in HTML <script> tags"
+    example = "'+{}()+'"
 
     def __init__(self):
         """Define static payloads"""

--- a/ava/actives/xxe.py
+++ b/ava/actives/xxe.py
@@ -2,6 +2,7 @@ import re
 import string
 from ava.common import utility
 from ava.common.check import _ValueCheck
+from ava.common.exception import InvalidFormatException
 
 
 # metadata
@@ -17,6 +18,7 @@ class XmlExternalEntityCheck(_ValueCheck):
     key = "xxe.value.file"
     name = "XML External Entity"
     description = "checks for xml external entity by accessing local files"
+    example = '<?xml version="1.0"?><!DOCTYPE {} [<!ENTITY {} SYSTEM "file:///etc/group">]><{}>&{};</{}>'
 
     def __init__(self):
         """Define static payloads"""
@@ -79,3 +81,16 @@ class XmlExternalEntityCheck(_ValueCheck):
             return True
         else:
             return False
+
+    def _check_payloads(self, payloads):
+        """
+        Checks if the payloads are adoptable for this class and modify the payloads to adjust to check function.
+        InvalidFormatException is raised, if a payload is not adoptable.
+        Children can override.
+        :param payloads: list of payloads
+        :return: list of modified payloads
+        """
+        for i, payload in enumerate(payloads):
+            if '/etc/group' not in payload:
+                raise InvalidFormatException("Payload of {} must include '/etc/group'".format(self.key))
+        return payloads

--- a/ava/actives/xxe.py
+++ b/ava/actives/xxe.py
@@ -16,7 +16,7 @@ class XmlExternalEntityCheck(_ValueCheck):
     """
     key = "xxe.value.file"
     name = "XML External Entity"
-    description = "Checks for XML External Entity by accessing local files"
+    description = "checks for xml external entity by accessing local files"
 
     def __init__(self):
         """Define static payloads"""

--- a/ava/blinds/xss.py
+++ b/ava/blinds/xss.py
@@ -1,5 +1,6 @@
 import base64
 from ava.common.check import _BlindCheck
+from ava.common.exception import InvalidFormatException
 
 # metadata
 name = __name__
@@ -43,6 +44,8 @@ class CrossSiteScriptingBlindDirectCheck(_BlindCheck):
         :return: list of modified payloads
         """
         for i, payload in enumerate(payloads):
+            if '{}' not in payload:
+                raise InvalidFormatException("Payload of {} must include '{{}}'".format(self.key))
             payloads[i] = payload.format(self._listener)
         return payloads
 
@@ -104,5 +107,7 @@ class CrossSiteScriptingBlindDynamicCheck(_BlindCheck):
 
         # generate payloads
         for i, payload in enumerate(payloads):
+            if '{}' not in payload:
+                raise InvalidFormatException("Payload of {} must include '{{}}'".format(self.key))
             payloads[i] = payload.format(script)
         return payloads

--- a/ava/common/check.py
+++ b/ava/common/check.py
@@ -17,6 +17,7 @@ class _BlindCheck(_Check):
     internal system. These checks do not raise issues directly. The listener server maintains issue information.
     """
     _payloads = []  # attribute should be populated by children's __init___ method
+    example = "Payload example"
 
     def payloads(self, url, target, value):
         """
@@ -28,6 +29,30 @@ class _BlindCheck(_Check):
         """
         # return
         return self._payloads
+
+    def _check_payloads(self, payloads):
+        """
+        Checks if the payloads are adoptable for this class and modify the payloads to adjust to check function.
+        InvalidFormatException is raised, if a payload is not adoptable.
+        Children can override.
+        :param payloads: list of payloads
+        :return: list of modified payloads
+        """
+        return payloads
+
+    def set_payloads(self, payloads):
+        """
+        Overwrite the check's payloads.
+        :param payloads: list of payloads
+        """
+        self._payloads = self._check_payloads(payloads)
+
+    def add_payloads(self, payloads):
+        """
+        Add payloads to the check's payloads.
+        :param payloads: list of payloads
+        """
+        self._payloads += self._check_payloads(payloads)
 
 
 class _PassiveCheck(_Check):
@@ -45,6 +70,7 @@ class _ActiveCheck(_Check):
     Parent class for active checks. Subclasses include simple, differential, and timing checks.
     """
     _payloads = []  # attribute should be populated by children's __init___ method
+    example = "Payload example"
 
     def payloads(self, url, target, value):
         """
@@ -55,6 +81,30 @@ class _ActiveCheck(_Check):
         :return: list of payloads
         """
         return self._payloads
+
+    def _check_payloads(self, payloads):
+        """
+        Checks if the payloads are adoptable for this class and modify the payloads to adjust to check function.
+        InvalidFormatException is raised, if a payload is not adoptable.
+        Children can override.
+        :param payloads: list of payloads
+        :return: list of modified payloads
+        """
+        return payloads
+
+    def set_payloads(self, payloads):
+        """
+        Overwrite the check's payloads.
+        :param payloads: list of payloads
+        """
+        self._payloads = self._check_payloads(payloads)
+
+    def add_payloads(self, payloads):
+        """
+        Add payloads to the check's payloads.
+        :param payloads: list of payloads
+        """
+        self._payloads += self._check_payloads(payloads)
 
 
 class _ValueCheck(_ActiveCheck):
@@ -151,3 +201,13 @@ class _TimingCheck(_ActiveCheck):
             return True
         else:
             return False
+
+    def _check_payloads(self, payloads):
+        """
+        Checks if the payloads are adoptable for this class and modify the payloads to adjust to check function.
+        InvalidFormatException is raised, if a payload is not adoptable.
+        Children can override.
+        :param payloads: list of payloads
+        :return: list of modified payloads
+        """
+        return [(payload, 9) for payload in payloads]

--- a/ava/readers/argument.py
+++ b/ava/readers/argument.py
@@ -4,7 +4,7 @@ from argparse import HelpFormatter
 
 class _ArgumentHelpFormatter(HelpFormatter):
 
-    def __init__(self, prog, indent_increment=2, max_help_position=30, width=None):
+    def __init__(self, prog, indent_increment=2, max_help_position=35, width=90):
         """Call parent with increased max_help_position"""
         super().__init__(prog, indent_increment=indent_increment, max_help_position=max_help_position, width=width)
 
@@ -46,7 +46,7 @@ class ArgumentReader:
 
     def dict(self, value):
         """
-        Converts a key=value string to a list. List will be combined into a dictionary.
+        Converts a key=value string to a list.
         :param value: string value
         :return: values as list
         """
@@ -77,6 +77,9 @@ class ArgumentReader:
         parser.add_argument('-e', '--actives', help="active checks as list", type=self.csv)
         parser.add_argument('--blinds', help="blind check as 'name=callback'", action='append', type=self.dict)
         parser.add_argument('--passives', help="passive checks as list", type=self.csv)
+        parser.add_argument('--set-payloads', help="set payloads as check=payload", type=self.dict, nargs='+')
+        parser.add_argument('--add-payloads', help="add payloads as check=payload", type=self.dict, nargs='+')
+        parser.add_argument('--show-examples', help="show examples of payloads", action='store_true')
         parser.add_argument('-o', '--report', help="json-formatted report file")
         parser.add_argument('--parameters', help="parameter as 'key=value'", action='append', type=self.dict)
         parser.add_argument('--cookies', help="cookie as 'key=value'", action='append', type=self.dict)
@@ -103,6 +106,18 @@ class ArgumentReader:
         for name in ["blinds", "cookies", "headers", "parameters"]:
             values = getattr(args, name)
             setattr(args, name, dict(values) if values else None)
+
+        # combine into list
+        for name in ["set_payloads", "add_payloads"]:
+            values = getattr(args, name)
+            if values is None:
+                continue
+            combined = {}
+            for key, value in values:
+                if key not in combined:
+                    combined[key] = []
+                combined[key].append(value)
+            setattr(args, name, combined)
 
         # convert
         return vars(args)

--- a/ava/scanner.py
+++ b/ava/scanner.py
@@ -50,10 +50,14 @@ def _print_modules():
     # print names and descriptions
     for package in packages:
         print(package + ':')
-        for name, description in utility.get_package_info(package):
-            print("  {:21s} {}".format(name, description))
+        for name, description, classes in utility.get_package_info(package):
+            print("  {:26s} {}".format(name, description))
+            if package == 'actives':
+                for key, desc in classes:
+                    print("    {:24s} {}".format(key, desc))
+                print('')
 
-        if package != packages[-1]:
+        if package not in ['actives', 'passives']:
             print('')
 
 

--- a/tests/actives/test_actives_header_injection.py
+++ b/tests/actives/test_actives_header_injection.py
@@ -1,5 +1,7 @@
 import pytest
+import re
 from ava.actives.header_injection import HeaderInjectionCheck
+from ava.common.exception import InvalidFormatException
 
 
 @pytest.fixture
@@ -40,3 +42,14 @@ class TestHeaderInjectionCheck:
         response.cookies = {}
         test = check.check(response, check._payloads[0])
         assert not test
+
+    def test_check_payloads_positive(self, check):
+        # positive
+        payloads = ["Set-Cookie: {}={}"]
+        assert re.match(r"^Set-Cookie: \w*=\w*$", check._check_payloads(payloads)[0])
+
+    def test_check_payloads_negative(self, check):
+        # negative
+        payloads = ["Invalid payload"]
+        with pytest.raises(InvalidFormatException):
+            check._check_payloads(payloads)

--- a/tests/actives/test_actives_open_redirect.py
+++ b/tests/actives/test_actives_open_redirect.py
@@ -1,5 +1,7 @@
 import pytest
+import re
 from ava.actives.open_redirect import OpenRedirectCheck, OpenRedirectHtmlCheck, OpenRedirectScriptCheck
+from ava.common.exception import InvalidFormatException
 
 
 @pytest.fixture
@@ -88,6 +90,17 @@ class TestOpenRedirectCheck:
         response.headers = {"Location": "http://www.notavanscan.com"}
         test = check.check(response, check._payloads[0])
         assert not test
+
+    def test_check_payloads_positive(self, check):
+        # positive
+        payloads = ["http://www.{}.com"]
+        assert re.match(r"^http://www.\w*.com$", check._check_payloads(payloads)[0])
+
+    def test_check_payloads_negative(self, check):
+        # negative
+        payloads = ["Invalid payload"]
+        with pytest.raises(InvalidFormatException):
+            check._check_payloads(payloads)
 
 
 class TestOpenRedirectHtmlCheck(TestOpenRedirectCheck):

--- a/tests/actives/test_actives_path_traversal.py
+++ b/tests/actives/test_actives_path_traversal.py
@@ -1,5 +1,6 @@
 import pytest
 from ava.actives.path_traversal import PathTraversalCheck
+from ava.common.exception import InvalidFormatException
 
 
 @pytest.fixture
@@ -52,3 +53,14 @@ class TestPathTraversalCheck:
         response.text = ""
         test = check.check(response, check._payloads[0])
         assert not test
+
+    def test_check_payloads_positive(self, check):
+        # positive
+        payloads = ["./etc/group"]
+        assert payloads == check._check_payloads(payloads)
+
+    def test_check_payloads_negative(self, check):
+        # negative
+        payloads = ["Invalid payload"]
+        with pytest.raises(InvalidFormatException):
+            check._check_payloads(payloads)

--- a/tests/actives/test_actives_shell_injection.py
+++ b/tests/actives/test_actives_shell_injection.py
@@ -1,5 +1,6 @@
 import pytest
 from ava.actives.shell_injection import ShellInjectionCheck, ShellInjectionTimingCheck
+from ava.common.exception import InvalidFormatException
 
 
 @pytest.fixture
@@ -56,6 +57,16 @@ class TestShellInjectionCheck:
         test = check.check(response, check._payloads[0])
         assert not test
 
+    def test_check_payloads_positive(self, check):
+        # positive
+        payloads = ["; id #"]
+        assert payloads == check._check_payloads(payloads)
+
+    def test_check_payloads_negative(self, check):
+        # negative
+        payloads = ["; ls #"]
+        with pytest.raises(InvalidFormatException):
+            check._check_payloads(payloads)
 
 class TestShellInjectionTimingCheck:
     payloads = [

--- a/tests/actives/test_actives_xxe.py
+++ b/tests/actives/test_actives_xxe.py
@@ -1,5 +1,7 @@
 import pytest
+import re
 from ava.actives.xxe import XmlExternalEntityCheck
+from ava.common.exception import InvalidFormatException
 
 
 @pytest.fixture
@@ -64,3 +66,12 @@ class TestXmlExternalEntityCheck:
         response.text = ""
         test = check.check(response, check._payloads[0])
         assert not test
+
+    def test_check_payloads_positive(self, check):
+        payloads = ['<?xml version="1.0"?><!DOCTYPE ava [<!ENTITY test SYSTEM "file:///etc/group">]><ava>&test;</ava>']
+        assert payloads == check._check_payloads(payloads)
+
+    def test_check_payloads_negative(self, check):
+        payloads = ["Invalid payload"]
+        with pytest.raises(InvalidFormatException):
+            check._check_payloads(payloads)

--- a/tests/auditors/test_auditors_json.py
+++ b/tests/auditors/test_auditors_json.py
@@ -4,7 +4,7 @@ from copy import copy
 from ava.actives.sql_injection import SqlInjectionCheck, SqlInjectionDifferentialCheck, SqlInjectionTimingCheck
 from ava.auditors.json import _JsonValueHandler, _JsonDifferentialHandler, _JsonTimingHandler, _JsonBlindHandler
 from ava.auditors.json import JsonAuditor
-from ava.blinds.xss import CrossSiteScriptingBlindCheck
+from ava.blinds.xss import CrossSiteScriptingBlindDirectCheck
 
 
 @pytest.fixture
@@ -169,7 +169,7 @@ class TestJsonBlindHandler:
     def test_generate_variations(self, handler, vector):
         generated = []
 
-        check = CrossSiteScriptingBlindCheck("http://localhost:8080/")
+        check = CrossSiteScriptingBlindDirectCheck("http://localhost:8080/")
 
         for payload in check.payloads(vector['url'], "ava", "avascan"):
             variation = copy(vector)

--- a/tests/auditors/test_auditors_parameter.py
+++ b/tests/auditors/test_auditors_parameter.py
@@ -9,7 +9,7 @@ from ava.auditors.parameter import _QueryParameterValueHandler, _QueryParameterD
 from ava.auditors.parameter import _QueryParameterTimingHandler, _QueryParameterBlindHandler
 from ava.auditors.parameter import _PostParameterValueHandler, _PostParameterDifferentialHandler
 from ava.auditors.parameter import _PostParameterTimingHandler, _PostParameterBlindHandler
-from ava.blinds.xss import CrossSiteScriptingBlindCheck
+from ava.blinds.xss import CrossSiteScriptingBlindDirectCheck
 
 
 @pytest.fixture
@@ -191,7 +191,7 @@ class TestQueryParameterBlindHandler:
         generated = []
 
         # check static payloads
-        check = CrossSiteScriptingBlindCheck("http://localhost:8080/")
+        check = CrossSiteScriptingBlindDirectCheck("http://localhost:8080/")
 
         for payload in check.payloads(vector['url'], "ava", "avascan"):
             # replace

--- a/tests/blinds/test_blinds_xss.py
+++ b/tests/blinds/test_blinds_xss.py
@@ -1,13 +1,31 @@
 import pytest
-from ava.blinds.xss import CrossSiteScriptingBlindCheck
+from ava.blinds.xss import CrossSiteScriptingBlindDirectCheck, CrossSiteScriptingBlindDynamicCheck
 
 
-class TestCrossSiteScriptingBlindCheck:
+class TestCrossSiteScriptingBlindDirectCheck:
     payloads = [
         '<img src="http://localhost:8080/">',
         '"><img src="http://localhost:8080/"><"',
         '<script src="http://localhost:8080/"></script>',
         '"><script src="http://localhost:8080/"></script><"',
+    ]
+
+    @pytest.fixture
+    def check(self):
+        listener = "http://localhost:8080/"
+        return CrossSiteScriptingBlindDirectCheck(listener)
+
+    def test_init(self, check):
+        assert check._payloads == self.payloads
+
+    def test_check_payloads(self, check):
+        payloads = ['<img src="{}">']
+        correct = ['<img src="http://localhost:8080/">']
+        assert correct == check._check_payloads(payloads)
+
+
+class TestCrossSiteScriptingBlindDynamicCheck:
+    payloads = [
         '<script>{}</script>',
         '"><script>{}</script><"',
         '<img src="x:#" onerror="{}">',
@@ -22,7 +40,7 @@ class TestCrossSiteScriptingBlindCheck:
     @pytest.fixture
     def check(self):
         listener = "http://localhost:8080/"
-        return CrossSiteScriptingBlindCheck(listener)
+        return CrossSiteScriptingBlindDynamicCheck(listener)
 
     def test_init(self, check):
         encoded = "aHR0cDovL2xvY2FsaG9zdDo4MDgwLw=="
@@ -32,3 +50,9 @@ class TestCrossSiteScriptingBlindCheck:
         generated = [payload.format(script) for payload in self.payloads]
         test = check._payloads
         assert test == generated
+
+    def test_check_payloads(self, check):
+        payloads = ["<script>{}</script>"]
+        correct = ["<script>s=document.createElement('script');s.src=atob('aHR0cDovL2xvY2FsaG9zdDo4MDgwLw==');document.head.appendChild(s);</script>"]
+        assert correct == check._check_payloads(payloads)
+

--- a/tests/blinds/test_blinds_xss.py
+++ b/tests/blinds/test_blinds_xss.py
@@ -1,5 +1,6 @@
 import pytest
 from ava.blinds.xss import CrossSiteScriptingBlindDirectCheck, CrossSiteScriptingBlindDynamicCheck
+from ava.common.exception import InvalidFormatException
 
 
 class TestCrossSiteScriptingBlindDirectCheck:
@@ -18,10 +19,15 @@ class TestCrossSiteScriptingBlindDirectCheck:
     def test_init(self, check):
         assert check._payloads == self.payloads
 
-    def test_check_payloads(self, check):
+    def test_check_payloads_positive(self, check):
         payloads = ['<img src="{}">']
         correct = ['<img src="http://localhost:8080/">']
         assert correct == check._check_payloads(payloads)
+
+    def test_check_payloads_negative(self, check):
+        payloads = ['Invalid payload']
+        with pytest.raises(InvalidFormatException):
+            check._check_payloads(payloads)
 
 
 class TestCrossSiteScriptingBlindDynamicCheck:
@@ -51,8 +57,12 @@ class TestCrossSiteScriptingBlindDynamicCheck:
         test = check._payloads
         assert test == generated
 
-    def test_check_payloads(self, check):
+    def test_check_payloads_positive(self, check):
         payloads = ["<script>{}</script>"]
         correct = ["<script>s=document.createElement('script');s.src=atob('aHR0cDovL2xvY2FsaG9zdDo4MDgwLw==');document.head.appendChild(s);</script>"]
         assert correct == check._check_payloads(payloads)
 
+    def test_check_payloads_negative(self, check):
+        payloads = ['Invalid payload']
+        with pytest.raises(InvalidFormatException):
+            check._check_payloads(payloads)

--- a/tests/common/test_common_check.py
+++ b/tests/common/test_common_check.py
@@ -27,6 +27,22 @@ class TestBlindCheck:
         test = check.payloads("", "", "")
         assert test == []
 
+    def test_check_payloads(self, check):
+        payloads = ["payload1", "payload2"]
+        assert payloads == check._check_payloads(payloads)
+
+    def test_set_payloads(self, check):
+        payloads = ["payload1", "payload2"]
+        check.set_payloads(payloads)
+        assert payloads == check._payloads
+
+    def test_add_payloads(self, check):
+        payloads = ["payload1", "payload2"]
+        check._payloads = ["payload3"]
+        correct = payloads + check._payloads
+        check.add_payloads(payloads)
+        assert sorted(check._payloads) == sorted(correct)
+
 
 class TestPassiveCheck:
     
@@ -49,6 +65,10 @@ class TestActiveCheck:
     def test_check(self, check):
         test = check.payloads("", "", "")
         assert test == []
+
+    def test_check_payloads(self, check):
+        payloads = ["payload1", "payload2"]
+        assert payloads == check._check_payloads(payloads)
 
 
 class TestValueCheck:
@@ -177,3 +197,8 @@ class TestTimingCheck:
 
         test = check.check({'original': original_response, 'timing': timing_response}, '', 9.00)
         assert not test
+
+    def test_check_payloads(self, check):
+        payloads = ["__import__('time').sleep(9)"]
+        test = check._check_payloads(payloads)
+        assert test == [(payloads[0], 9)]

--- a/tests/common/test_common_config.py
+++ b/tests/common/test_common_config.py
@@ -15,6 +15,10 @@ def test_check_modules_positive(mocker):
     test = config._check_modules("actives", ["xss", "open_redirect"])
     assert test == ["xss", "open_redirect"]
 
+    # key
+    test = config._check_modules("actives", ["xss.value.href"])
+    assert test == ["xss.value.href"]
+
 
 def test_check_modules_negative(mocker):
     # __init__
@@ -26,6 +30,10 @@ def test_check_modules_negative(mocker):
     mocker.patch("os.listdir", return_value=["__init__.py", "xss.py", "open_redirect.py"])
     with pytest.raises(InvalidValueException):
         config._check_modules("actives", ["module_does_not_exist"])
+
+    # non-existent key
+    with pytest.raises(InvalidValueException):
+        config._check_modules("actives", ["non.existent.key"])
 
 
 def test_check_url_positive():

--- a/tests/common/test_common_config.py
+++ b/tests/common/test_common_config.py
@@ -195,12 +195,33 @@ def test_check_alternative_url_negative():
         config._check_alternative_url("ftp://127.0.0.1")
 
 
+def test_check_keys_positive():
+    # actives
+    values = {'xss.value.tag': ["payload"]}
+    test = config._check_keys(values)
+    assert test == values
+
+    # blinds
+    values = {'xss.blind.direct': ["payload"]}
+    test = config._check_keys(values)
+    assert test == values
+
+
+def test_check_keys_negative():
+    # non-existent key
+    values = {'non.existent.key': ["payload"]}
+    with pytest.raises(InvalidValueException):
+        config._check_keys(values)
+
+
 def test_generate_positive():
     users = {
         'auditors': ["parameter", "cookie"],
         'actives': ["xss", "open_redirect"],
         'blinds': {'xss': "http://localhost/"},
         'passives': ["pii"],
+        'set_payloads': {'xss.value.tag': "value"},
+        'add_payloads': {'xss.blind.direct': "value"},
         'report': "report.json",
         'cookies': {'key': "value"},
         'headers': {'key': "value"},
@@ -227,6 +248,8 @@ def test_generate_positive():
         'actives': ["xss", "open_redirect"],
         'blinds': {'xss': "http://localhost/"},
         'passives': ["pii"],
+        'set_payloads': {'xss.value.tag': "value"},
+        'add_payloads': {'xss.blind.direct': "value"},
         'report': "report.json",
         'cookies': {'key': "value"},
         'headers': {'key': "value"},

--- a/tests/handlers/test_handlers_blind.py
+++ b/tests/handlers/test_handlers_blind.py
@@ -1,5 +1,5 @@
 import pytest
-from ava.blinds.xss import CrossSiteScriptingBlindCheck
+from ava.blinds.xss import CrossSiteScriptingBlindDirectCheck
 from ava.common.check import _BlindCheck
 from ava.handlers.blind import _BlindHandler
 
@@ -32,7 +32,7 @@ class TestBlindHandler:
         assert handler.handles == _BlindCheck
 
     def test_blind_execute_check_positive(self, handler, vector, response, mocker):
-        check = CrossSiteScriptingBlindCheck("http://localhost:8080/")
+        check = CrossSiteScriptingBlindDirectCheck("http://localhost:8080/")
         auditable = {'vector': vector, 'target': "param", 'payload': check._payloads[0], 'value': check._payloads[0]}
 
         # mock
@@ -46,7 +46,7 @@ class TestBlindHandler:
         assert test == []
 
     def test_execute_check_negative(self, handler, vector, mocker):
-        check = CrossSiteScriptingBlindCheck("http://localhost:8080/")
+        check = CrossSiteScriptingBlindDirectCheck("http://localhost:8080/")
         auditable = {'vector': vector}
 
         # no targets

--- a/tests/readers/test_readers_argument.py
+++ b/tests/readers/test_readers_argument.py
@@ -78,6 +78,11 @@ class TestArgumentReader:
         test = reader.parse()
         assert sorted(test['actives']) == ["open_redirect", "xss"]
 
+        # payloads
+        reader = ArgumentReader(['--set-payloads', "xss=payload", "xss=payload2", "blind=payload3"])
+        test = reader.parse()
+        assert test['set_payloads'] == {'xss': ["payload", "payload2"], 'blind': ["payload3"]}
+
         # auditors
         reader = ArgumentReader(['-a', "parameters, cookies"])
         test = reader.parse()

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -1,12 +1,13 @@
 import pytest
 import logging
 import sys
+import re
 import ava.scanner
 import ava.common.config
 import ava.common.utility
 from copy import copy
-from ava.actives.xss import CrossSiteScriptingCheck
-from ava.blinds.xss import CrossSiteScriptingBlindCheck
+from ava.actives.xss import CrossSiteScriptingCheck, CrossSiteScriptingLinkCheck, CrossSiteScriptingScriptCheck
+from ava.blinds.xss import CrossSiteScriptingBlindDirectCheck
 from ava.passives.pii import PersonallyIdentifiableInformationCheck
 from ava.common.exception import InvalidValueException, UnknownKeyException, InvalidFormatException
 from ava.common.exception import MissingComponentException
@@ -151,10 +152,16 @@ def test_load_checks(mocker):
     assert isinstance(test[0], PersonallyIdentifiableInformationCheck)
 
     # blinds
-    mocker.patch("ava.common.utility.get_package_classes", return_value=[CrossSiteScriptingBlindCheck])
+    mocker.patch("ava.common.utility.get_package_classes", return_value=[CrossSiteScriptingBlindDirectCheck])
     configs = {'actives': None, 'passives': None, 'blinds': {'xss': "http://localhost:8080/"}}
     test = ava.scanner._load_checks(configs)
-    assert isinstance(test[0], CrossSiteScriptingBlindCheck)
+    assert isinstance(test[0], CrossSiteScriptingBlindDirectCheck)
+
+    # blinds with key
+    mocker.patch("ava.common.utility.get_package_classes", return_value=[CrossSiteScriptingBlindDirectCheck])
+    configs = {'actives': None, 'passives': None, 'blinds': {'xss.blind.direct': "http://localhost:8080/"}}
+    test = ava.scanner._load_checks(configs)
+    assert isinstance(test[0], CrossSiteScriptingBlindDirectCheck)
 
     # no checks
     configs = {'actives': None, 'passives': None, 'blinds': None}
@@ -162,11 +169,52 @@ def test_load_checks(mocker):
     assert test == []
 
 
+def test_modify_payloads_positive():
+    # set payloads actives
+    checks = [CrossSiteScriptingCheck()]
+    values = {'xss.value.tag': ["test<{}></{}>"]}
+    test = ava.scanner._modify_payloads(checks, values, True)
+    assert re.match(r"^test<\w*></\w*>$", test[0]._payloads[0])
+
+    # add payloads
+    checks = [CrossSiteScriptingCheck()]
+    values = {'xss.value.tag': ["test<{}></{}>"]}
+    test = ava.scanner._modify_payloads(checks, values, False)
+    found = False
+    for payload in test[0]._payloads:
+        found |= re.match(r"^test<\w*></\w*>$", payload) is not None
+    assert found
+
+    # set payloads blinds
+    checks = [CrossSiteScriptingBlindDirectCheck("http://localhost:8080/")]
+    values = {'xss.blind.direct': ["payload"]}
+    test = ava.scanner._modify_payloads(checks, values, True)
+    assert test[0]._payloads == ["payload"]
+
+    # add payloads blinds
+    checks = [CrossSiteScriptingBlindDirectCheck("http://localhost:8080/")]
+    values = {'xss.blind.dynamic': ["payload"]}
+    correct = checks[0]._payloads
+    correct.append("payload")
+    test = ava.scanner._modify_payloads(checks, values, False)
+    assert test[0]._payloads == correct
+
+
+def test_modify_payloads_negative():
+    # set payloads to one check
+    checks = [CrossSiteScriptingLinkCheck(), CrossSiteScriptingScriptCheck()]
+    values = {'xss.value.href': ["test');{}();//"]}
+    test = ava.scanner._modify_payloads(checks, values, True)
+    for payload in test[1]._payloads:
+        assert re.match(r"^test'\);\w*\(\);//$", payload) is None
+
+
 def test_run_scanner_positive(mocker):
     configs = {"hars": ["test.har"],
                "report": None,
                "auditors": [],
                "actives": [], "blinds": {}, "passives": [],
+               "set_payloads": {}, "add_payloads": {},
                "reduce": False, "summary": False}
     vector = {
         "url": "http://www.avascan.com/",
@@ -204,6 +252,7 @@ def test_run_scanner_negative(mocker):
                "report": None,
                "auditors": [],
                "actives": [], "blinds": {}, "passives": [],
+               "set_payloads": {}, "add_payloads": {},
                "reduce": True, "summary": False}
 
     # empty vectors
@@ -223,6 +272,11 @@ def test_main_positive(mocker):
     mocker.patch("os.path.isfile", return_value=True)
     mocker.patch("ava.common.config.generate")
     mocker.patch("ava.scanner._run_scanner")
+    test = ava.scanner.main(args)
+    assert test == 0
+
+    # show examples
+    args = ["--show-examples"]
     test = ava.scanner.main(args)
     assert test == 0
 


### PR DESCRIPTION
Add ability to set/add payloads at command line. This options receive dictionary whose key represents a check class and whose value represents payload. `ava -l` shows keys representing check classes. `ava --show-examples` shows examples of payloads.
In addition, I divided CrossSiteScriptingBlindCheck into two classes because it had two types of payloads, direct and dynamic. This change made it easier to send appropriate payloads to blind xss classes.